### PR TITLE
Fix imports to remove warning per Flask recommendation.

### DIFF
--- a/flask_featureflags/__init__.py
+++ b/flask_featureflags/__init__.py
@@ -21,7 +21,7 @@ from flask import abort, current_app, url_for
 from flask import redirect as _redirect
 from flask.signals import Namespace
 
-__version__ = '0.7-dev'
+__version__ = '1.0'
 
 log = logging.getLogger(u'flask-featureflags')
 

--- a/flask_featureflags/contrib/inline/__init__.py
+++ b/flask_featureflags/contrib/inline/__init__.py
@@ -1,7 +1,7 @@
 from flask import current_app
-from flask.ext.featureflags import FEATURE_FLAGS_CONFIG
-from flask.ext.featureflags import NoFeatureFlagFound
-from flask.ext.featureflags import log
+from flask_featureflags import FEATURE_FLAGS_CONFIG
+from flask_featureflags import NoFeatureFlagFound
+from flask_featureflags import log
 
 
 class InlineFeatureFlag(object):

--- a/flask_featureflags/contrib/sqlalchemy/__init__.py
+++ b/flask_featureflags/contrib/sqlalchemy/__init__.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, Integer, Boolean, String
 from sqlalchemy.orm.exc import NoResultFound
 from flask import current_app
-from flask.ext.featureflags import NoFeatureFlagFound, log
+from flask_featureflags import NoFeatureFlagFound, log
 
 
 class SQLAlchemyFeatureFlags(object):


### PR DESCRIPTION
http://flask.pocoo.org/docs/0.12/extensiondev/#extension-import-transition

Duplicate of https://github.com/trustrachel/Flask-FeatureFlags/pull/20 as that PR is clearly not getting landed and we need to take ownership of the library on PyPi.